### PR TITLE
WIP: Add Ooo binder.

### DIFF
--- a/test/matchit/ds.cpp
+++ b/test/matchit/ds.cpp
@@ -33,3 +33,24 @@ TEST(Ds, vecOoo)
   EXPECT_TRUE(matchPattern(std::vector<int32_t>{123, 456}, ds(ooo, 456)));
   EXPECT_TRUE(matchPattern(std::vector<int32_t>{123, 456}, ds(123, ooo, 456)));
 }
+
+TEST(Ds, vecOooBinder)
+{
+  auto const vec = std::vector<int32_t>{123, 456};
+  Id<Span<int32_t>> span;
+  EXPECT_TRUE(matchPattern(vec, ds(ooo(span))));
+  EXPECT_EQ(span.value().mSize, 2);
+  EXPECT_EQ(span.value().mData[0], 123);
+  EXPECT_EQ(span.value().mData[1], 456);
+
+  #if 0
+  // FIXME, need to handle span for rvalue, store an vector instead.
+  Id<Span<int32_t>> span2;
+  EXPECT_TRUE(matchPattern(std::vector<int32_t>{123, 456}, ds(ooo(span2))));
+  // This line overwrite the temp memory released above.
+  EXPECT_TRUE(matchPattern(std::vector<int32_t>{789, 321}, ds(ooo)));
+  EXPECT_EQ(span2.value().mSize, 2);
+  EXPECT_EQ(span2.value().mData[0], 123);
+  EXPECT_EQ(span2.value().mData[1], 456);
+  #endif
+}


### PR DESCRIPTION
Ooo binder can happens as sub patterns of `Slice` patterns in Rust.

We need to support it for array / vector.

TODO: handle the binding of rvalue of array / vector. `span` is not the right option. Need a std::variant<std::span<T>. std::vector<T>>.